### PR TITLE
Fix scroll snap behavior on all screen sizes

### DIFF
--- a/components/StandardSection.tsx
+++ b/components/StandardSection.tsx
@@ -60,7 +60,7 @@ const StandardSection: React.FC<StandardSectionProps> = ({
   ), [content.content]);
 
   const contentElement = (
-    <div className="px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 2xl:px-20 py-6 w-full bg-opacity-0 justify-content-center">
+    <div className={`px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 2xl:px-20 py-6 w-full bg-opacity-0 justify-content-center ${isExpanded ? 'h-auto' : ''}`}>
       {/* Standard sections with overlay design */}
       <div className="relative w-full">
         {/* Content Area - Fixed or Expandable Height */}
@@ -68,7 +68,7 @@ const StandardSection: React.FC<StandardSectionProps> = ({
           ref={scrollableContentRef}
           className={`${
             isExpanded 
-              ? 'max-h-[75vh] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent' 
+              ? 'max-h-[90vh] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-400 scrollbar-track-transparent' 
               : 'overflow-hidden'
           }`}
           style={!isExpanded && availableHeight ? { height: `${availableHeight}px` } : {}}
@@ -129,7 +129,7 @@ const StandardSection: React.FC<StandardSectionProps> = ({
   return (
     <div 
       ref={sectionRef}
-      className={`md:snap-start ${section.backgroundColor} w-screen h-screen flex items-center justify-center overflow-hidden`}
+      className={`snap-start ${section.backgroundColor} w-screen h-screen flex ${isExpanded ? 'items-start justify-center pt-4' : 'items-center justify-center'} overflow-hidden`}
       id={section.id}
       style={{ touchAction: 'pan-y', overscrollBehavior: 'contain' }}
     >

--- a/components/VideoBackgroundSection.tsx
+++ b/components/VideoBackgroundSection.tsx
@@ -74,7 +74,7 @@ const VideoBackgroundSection: React.FC<VideoBackgroundSectionProps> = ({
 
   return (
     <div 
-      className={`md:snap-start ${section.backgroundColor} w-screen h-screen relative overflow-hidden`}
+      className={`snap-start ${section.backgroundColor} w-screen h-screen relative overflow-hidden`}
       id={section.id}
       style={{ touchAction: 'pan-y', overscrollBehavior: 'contain' }}
     >

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -76,7 +76,7 @@ const Home = (props: {
         </Head>
       </div>
 
-      <div className="md:snap-y md:snap-proximity min-h-full h-screen w-auto overflow-y-scroll overflow-x-hidden bg-white dark:bg-dark-bg transition-colors duration-300">
+      <div className="snap-y snap-mandatory min-h-full h-screen w-auto overflow-y-scroll overflow-x-hidden bg-white dark:bg-dark-bg transition-colors duration-300">
         <Navigation
           variant="standard"
           SiteTitle={props.SiteTitle}
@@ -91,7 +91,7 @@ const Home = (props: {
         {SECTIONS_CONFIG
           .filter(section => section.enabled)
           .map(section => (
-            <div key={section.id} className="md:snap-start">
+            <div key={section.id}>
               <MarkdownContentComponent
                 section={section}
                 content={props.content[section.contentFile]}
@@ -101,7 +101,7 @@ const Home = (props: {
 
         {/* Blog Section - Endless Scroll */}
         <div
-          className="md:snap-start bg-cyan-500 dark:bg-cyan-600 w-screen min-h-screen transition-colors duration-300"
+          className="snap-start bg-cyan-500 dark:bg-cyan-600 w-screen min-h-screen transition-colors duration-300"
           id="blog"
         >
           <BlogSection posts={props.posts} />


### PR DESCRIPTION
## Summary
- Fixed scroll snap not working by changing from `snap-proximity` to `snap-mandatory`
- Removed `md:` prefixes to enable scroll snap on all screen resolutions
- Enhanced Continue Reading layout to work properly with snap behavior

## Changes Made
- **Main container**: Changed `snap-y snap-proximity` to `snap-y snap-mandatory` for reliable snapping behavior
- **Screen size support**: Removed `md:` prefixes from snap classes to work on mobile and all screen sizes
- **Layout improvements**: Updated expanded content layout to maintain snap points while allowing content expansion

## Technical Details
The previous implementation used `snap-proximity` which only snapped when "close enough" to a snap point, often resulting in no snapping behavior. The `snap-mandatory` approach forces the browser to always snap to the nearest snap point, providing the expected smooth section-by-section scrolling.

## Test Results
- ✅ Scroll snap works reliably on all screen sizes
- ✅ Continue Reading expansion maintains snap behavior
- ✅ All sections snap properly with consistent behavior
- ✅ Build passes with no errors

🤖 Generated with [Claude Code](https://claude.ai/code)