### PR TITLE
Fix Cloudflare Pages build warnings and update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "set WEBSITE_URL=https://yuvalararat.com && next build",
+    "build:cloudflare": "npx @cloudflare/next-on-pages",
     "start": "next start",
     "lint": "next lint"
   },
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.23.3",
+    "@cloudflare/next-on-pages": "^1.13.5",
     "@fullhuman/postcss-purgecss": "^5.0.0",
     "@types/node": "20.0.0",
     "@types/react": "18.2.0",

--- a/posts/2020-07-stress-testing-customisations-on-aem-author-with-siege.md
+++ b/posts/2020-07-stress-testing-customisations-on-aem-author-with-siege.md
@@ -4,7 +4,7 @@ date: '2017-05-09T16:45:26+12:00'
 status: publish
 permalink: /2017/05/stress-testing-customisations-on-aem-author-with-siege
 author: 'Yuval Ararat'
-excerpt: ''
+excerpt: 'Learn how to stress test AEM Author customizations using Siege tool to ensure performance and stability under load.'
 type: post
 id: 1431
 thumbnail: ''


### PR DESCRIPTION
- Add @cloudflare/next-on-pages@^1.13.5 to devDependencies for stable version
- Add build:cloudflare script with modern command (removes deprecated pre-v1)
- Fix missing excerpt for stress testing blog post to resolve build warning
- Ready for updated Cloudflare Pages build configuration

🤖 Generated with [Claude Code](https://claude.ai/code)